### PR TITLE
Fix sale date queries

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-custom-table.php
+++ b/includes/data-stores/class-wc-product-data-store-custom-table.php
@@ -762,8 +762,8 @@ class WC_Product_Data_Store_Custom_Table extends WC_Product_Data_Store_CPT imple
 			SELECT products.product_id
 			FROM {$wpdb->prefix}wc_products as products
 			LEFT JOIN {$wpdb->posts} as posts ON products.product_id = posts.ID
-			WHERE products.`sale_price_dates_from` > 0
-			AND products.`sale_price_dates_from` < %s
+			WHERE products.`date_on_sale_from` > 0
+			AND products.`date_on_sale_from` < %s
 			AND products.`price` != products.`sale_price`
 		", current_time( 'timestamp', true ) ) ); // WPCS: db call ok, cache ok.
 	}
@@ -781,8 +781,8 @@ class WC_Product_Data_Store_Custom_Table extends WC_Product_Data_Store_CPT imple
 			SELECT products.product_id
 			FROM {$wpdb->prefix}wc_products as products
 			LEFT JOIN {$wpdb->posts} as posts ON products.product_id = posts.ID
-			WHERE products.`sale_price_dates_to` > 0
-			AND products.`sale_price_dates_to` < %s
+			WHERE products.`date_on_sale_to` > 0
+			AND products.`date_on_sale_to` < %s
 			AND products.`price` != products.`regular_price`
 		", current_time( 'timestamp', true ) ) ); // WPCS: db call ok, cache ok.
 	}


### PR DESCRIPTION
The queries for getting the sale dates were still referencing old column names. This updates the queries to the new column names.