### PR TITLE
Fix on sale products

### DIFF
--- a/includes/class-wc-product-tables-migrate-data.php
+++ b/includes/class-wc-product-tables-migrate-data.php
@@ -199,6 +199,10 @@ class WC_Product_Tables_Migrate_Data {
 				} else {
 					$meta_value = null;
 				}
+			} elseif ( '_sale_price' === $meta_key ) {
+				// replace empty strings (used to represent products not on sale) with NULL as the type of the field
+				// sale_price is double and an empty string is not a valid value.
+				$meta_value = ( isset( $metas['_sale_price'] ) && '' !== $metas['_sale_price'][0] ) ? $metas['_sale_price'][0] : null;
 			} else {
 				$meta_value = isset( $metas[ $meta_key ] ) ? $metas[ $meta_key ][0] : null;
 			}


### PR DESCRIPTION
When importing data, this commit changes the value of the field `sale_price` of products not on sale from an empty string to `NULL`. This is necessary because the type of the field `sale_price` is `double` and MySQL was silently converting empty strings to `0`. This conversion meant that all products were shown as being on sale.

This PR also includes a commit that moves code to migrate core product data to its own method.

Fixes #28