### PR TITLE
Fix retrieval of grouped products children

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-custom-table.php
+++ b/includes/data-stores/class-wc-product-data-store-custom-table.php
@@ -59,7 +59,7 @@ class WC_Product_Data_Store_Custom_Table extends WC_Data_Store_WP implements WC_
 		'image_gallery' => 'gallery_image_ids',
 		'upsell'        => 'upsell_ids',
 		'cross_sell'    => 'cross_sell_ids',
-		'child'         => 'children',
+		'grouped'       => 'children',
 	);
 
 	/**

--- a/includes/data-stores/class-wc-product-grouped-data-store-custom-table.php
+++ b/includes/data-stores/class-wc-product-grouped-data-store-custom-table.php
@@ -69,4 +69,14 @@ class WC_Product_Grouped_Data_Store_Custom_Table extends WC_Product_Data_Store_C
 			)
 		); // WPCS: db call ok, cache ok.
 	}
+
+	/**
+	 * Empty method that overrides parent method and prevent the use of
+	 * WC_Product_Grouped::extra_data. If we don't do this, the post meta
+	 * '_children' will be used instead of product relationships from the
+	 * table wp_wc_product_relationships to get grouped products children.
+	 *
+	 * @param WC_Product $product Product object.
+	 */
+	protected function read_extra_data( &$product ) {}
 }


### PR DESCRIPTION
This commit fixes the way the grouped property 'children' is populated. Before this change grouped products were displaying only the first child and all other children were missing.

This was happening because WC_Product_Data_Store_Custom_Table::read_extra_data() was using WC_Product_Grouped::extra_data to get grouped products children from a single `_children` post meta entry. Modifying just the data store, the only solution I could find was to override WC_Product_Data_Store_Custom_Table::read_extra_data() in WC_Product_Grouped_Data_Store_Custom_Table with an empty method.

There was also another problem that needed to be addressed where the relationship type for grouped products children in WC_Product_Data_Store_Custom_Table::relationships was wrong. It was 'child', but the correct value is 'grouped'.

I would appreciate a review of this PR especially because I'm not sure if overriding WC_Product_Data_Store_Custom_Table::read_extra_data() is the best solution to this problem.