### PR TITLE
Fix product image migration

### DIFF
--- a/includes/class-wc-product-tables-migrate-data.php
+++ b/includes/class-wc-product-tables-migrate-data.php
@@ -22,7 +22,7 @@ class WC_Product_Tables_Migrate_Data {
 		// List of post meta keys that will be migrated to fields in the new wp_wc_products table.
 		'product' => array(
 			'_sku',
-			'_image_id',
+			'_thumbnail_id',
 			'_height',
 			'_width',
 			'_length',
@@ -207,7 +207,12 @@ class WC_Product_Tables_Migrate_Data {
 				$meta_value = isset( $metas[ $meta_key ] ) ? $metas[ $meta_key ][0] : null;
 			}
 
-			$field_name              = ltrim( $meta_key, '_' );
+			if ( '_thumbnail_id' === $meta_key ) {
+				$field_name = 'image_id';
+			} else {
+				$field_name = ltrim( $meta_key, '_' );
+			}
+
 			$new_data[ $field_name ] = $meta_value;
 		}
 


### PR DESCRIPTION
The product main image was not being imported because the field name is the new table structure is different from the old name. As a result, all products single pages were displayed without an image.

The postmeta that stores the image ID is called `_thumbnail_id`, but the field name in the table `wp_wc_products` is called `image_id`. This commit fixes this issue by simply renaming the field when importing product data from the old table structure.