### PR TITLE
Fix image relationship type

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-custom-table.php
+++ b/includes/data-stores/class-wc-product-data-store-custom-table.php
@@ -56,10 +56,10 @@ class WC_Product_Data_Store_Custom_Table extends WC_Data_Store_WP implements WC_
 	 * @var   array
 	 */
 	protected $relationships = array(
-		'image_gallery' => 'gallery_image_ids',
-		'upsell'        => 'upsell_ids',
-		'cross_sell'    => 'cross_sell_ids',
-		'grouped'       => 'children',
+		'image'      => 'gallery_image_ids',
+		'upsell'     => 'upsell_ids',
+		'cross_sell' => 'cross_sell_ids',
+		'grouped'    => 'children',
 	);
 
 	/**


### PR DESCRIPTION
The name of the image relationship type was wrong, and thus image galleries were not being displayed in the product single page.