### PR TITLE
Remove product variation attributes from postmeta after migrating data

### DIFF
--- a/includes/class-wc-product-tables-migrate-data.php
+++ b/includes/class-wc-product-tables-migrate-data.php
@@ -396,10 +396,21 @@ class WC_Product_Tables_Migrate_Data {
 	 * @return void
 	 */
 	protected static function clean_old_data( $product_id ) {
+		global $wpdb;
+
 		$meta_keys = array_merge( self::$meta_keys['product'], self::$meta_keys['custom'] );
 
 		foreach ( $meta_keys as $meta_key ) {
 			delete_post_meta( $product_id, $meta_key );
 		}
+
+		// remove product variation attributes.
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key LIKE %s",
+				$product_id,
+				$wpdb->esc_like( 'attribute_' ) . '%'
+			)
+		);
 	}
 }


### PR DESCRIPTION
This commit changes the `wp wc-product-tables migrate-data` command to also remove product variation attributes from postmeta when the parameter `--clean-old-data` is passed.