### PR TITLE
Display all attribute values when none is selected

### DIFF
--- a/includes/data-stores/class-wc-product-variable-data-store-custom-table.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-custom-table.php
@@ -146,7 +146,7 @@ class WC_Product_Variable_Data_Store_Custom_Table extends WC_Product_Data_Store_
 				);
 
 				// Empty value indicates that all options for given attribute are available.
-				if ( in_array( '', $values, true ) || empty( $values ) ) {
+				if ( in_array( null, $values, true ) || empty( $values ) ) {
 					$values = $attribute->get_slugs();
 				} elseif ( ! $attribute->is_taxonomy() ) {
 					$text_attributes          = $attribute->get_options();


### PR DESCRIPTION
WC should display all attribute values when none is selected in the product single page of a variable product. This was not happening because `$wpdb` returns `null` for empty values instead of a empty string and thus the check that was modified by this commit was failing.

To check this PR, using WC sample data, open "V-Neck T-Shirt" single page and verify if the "Size" select box list the size options.