### PR TITLE
Fixed small bug that break stock management

### DIFF
--- a/includes/class-wc-product-tables-backwards-compatibility.php
+++ b/includes/class-wc-product-tables-backwards-compatibility.php
@@ -460,8 +460,9 @@ class WC_Product_Tables_Backwards_Compatibility {
 		}
 
 		// Set stock_quantity to NULL if not managing stock.
-		$args['value']  = 'NULL';
+		$args['value']  = null;
 		$args['format'] = '';
+
 		return $this->update_in_product_table( $args );
 	}
 


### PR DESCRIPTION
`'NULL'` is treated as a string, so just changing this line the bug is fixed.

Found this running our unit tests.