### PR TITLE
Allow $meta_value and $delete_all while deleting metadata

### DIFF
--- a/includes/class-wc-product-tables-backwards-compatibility.php
+++ b/includes/class-wc-product-tables-backwards-compatibility.php
@@ -225,11 +225,15 @@ class WC_Product_Tables_Backwards_Compatibility {
 		);
 
 		if ( ! empty( $args['delete_all'] ) ) {
+			// Properly convert null values to mysql.
+			$delete_all_value = is_null( $args['value'] ) ? 'NULL' : "'" . esc_sql( $args['value'] ) . "'";
+
+			// Update all values.
 			$query  = "UPDATE {$wpdb->prefix}wc_products";
-			$query .= ' SET ' . esc_sql( $args['column'] ) . ' = ' . esc_sql( $args['value'] );
+			$query .= ' SET ' . esc_sql( $args['column'] ) . ' = ' . $delete_all_value;
 
 			if ( isset( $args['meta_value'] ) ) {
-				$query .= ' WHERE ' . esc_sql( $args['column'] ) . ' = ' . esc_sql( $args['meta_value'] );
+				$query .= ' WHERE ' . esc_sql( $args['column'] ) . ' = ' . "'" . esc_sql( $args['meta_value'] ) . "'";
 			}
 
 			$update_success = (bool) $wpdb->query( $query ); // WPCS: unprepared SQL ok.


### PR DESCRIPTION
Handle backwards compatibility when using `delete_metadata( 'post', $product_id, $meta_key, $meta_value, $delete_all )`.

Closees #42 