### PR TITLE
Attributes metadata backwards compatibility

### DIFF
--- a/tests/unit-tests/class-wc-tests-backwards-compatibility.php
+++ b/tests/unit-tests/class-wc-tests-backwards-compatibility.php
@@ -923,7 +923,12 @@ class WC_Tests_Backwards_Compatibility extends WC_Unit_Test_Case {
 		$this->assertEquals( array(), $this->get_from_meta_table( $product->get_id(), '_product_attributes' ) );
 		$this->assertEquals( $updated, get_post_meta( $product->get_id(), '_product_attributes', true ) );
 
-		// @todo Instantiate a product object and check it got updated should pass.
+		$_product = wc_get_product( $product->get_id() );
+		$retrieved_attribute = current( $_product->get_attributes() );
+		$this->assertEquals( 1, count( $_product->get_attributes() ) );
+		$this->assertEquals( 'Test Attribute 2', $retrieved_attribute->get_name() );
+		$this->assertEquals( array( 'Chicken', 'Nuggets' ), $retrieved_attribute->get_options() );
+
 		delete_post_meta( $product->get_id(), '_product_attributes' );
 		$this->assertEquals( array(), get_post_meta( $product->get_id(), '_product_attributes', true ) );
 
@@ -962,7 +967,9 @@ class WC_Tests_Backwards_Compatibility extends WC_Unit_Test_Case {
 		$this->assertEquals( array(), $this->get_from_meta_table( $product->get_id(), '_default_attributes' ) );
 		$this->assertEquals( $default, get_post_meta( $product->get_id(), '_default_attributes', true ) );
 
-		// @todo Instantiate a product object and check it got updated should pass.
+		$_product = wc_get_product( $product->get_id() );
+		$this->assertEquals( $default, $_product->get_default_attributes() );
+
 		delete_post_meta( $product->get_id(), '_default_attributes' );
 		$this->assertEquals( array(), get_post_meta( $product->get_id(), '_default_attributes', true ) );
 


### PR DESCRIPTION
Closes #38 

To test: Run unit tests.

The default attribute unit test is currently failing. I believe it has exposed a problem with the data store. To verify the problem is actually coming from the data store you can comment out line 968 and observe that this fails:

```
		$product = new WC_Product_Simple();
		$product->set_attributes( $attributes );
		$product->set_default_attributes( $default );
		$product->save();

		$_product = wc_get_product( $product->get_id() );
		$this->assertEquals( $default, $_product->get_default_attributes() );
```

PR for data store fix coming soon.