### PR TITLE
Fix default attribute load/save

### DIFF
--- a/includes/class-wc-product-tables-backwards-compatibility.php
+++ b/includes/class-wc-product-tables-backwards-compatibility.php
@@ -838,7 +838,7 @@ class WC_Product_Tables_Backwards_Compatibility {
 
 		$product = wc_get_product( $args['product_id'] );
 		if ( $product ) {
-			return $product->get_default_attributes( 'edit' );
+			return array( array( $product->get_default_attributes( 'edit' ) ) );
 		}
 
 		return array();


### PR DESCRIPTION
See #56

To test: Verify unit test `test_product_default_attributes_mapping` passes. That tests saving/loading a product with default attributes as part of the test flow.