### PR TITLE
Exclude tests from the group 'core-only'

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,6 +14,11 @@
 			<directory suffix=".php">./../woocommerce/tests/unit-tests</directory>
 		</testsuite>
 	</testsuites>
+	<groups>
+		<exclude>
+			<group>core-only</group>
+		</exclude>
+	</groups>
 	<filter>
 		<whitelist addUncoveredFilesFromWhitelist="true">
 			<directory suffix=".php">./../woocommerce/includes</directory>


### PR DESCRIPTION
This group of unit tests was created to identify tests that don't work and shouldn't work in the context of the custom product tables plugin so they are skipped. This PR depends on WC core commit https://github.com/woocommerce/woocommerce/commit/d55c0d63b1a27d0edc76d57acaac7221d59b54fb