### PR TITLE
Remove WC_USE_TRANSACTIONS constant as it is already defined by WC core

### DIFF
--- a/tests/class-wcpt-unit-tests-bootstrap.php
+++ b/tests/class-wcpt-unit-tests-bootstrap.php
@@ -34,7 +34,6 @@ class WCPT_Unit_Tests_Bootstrap {
 	 */
 	public function __construct() {
 		$this->wp_tests_dir = getenv( 'WP_TESTS_DIR' ) ? getenv( 'WP_TESTS_DIR' ) : '/tmp/wordpress-tests-lib';
-		define( 'WC_USE_TRANSACTIONS', false );
 
 		// load test function so tests_add_filter() is available.
 		require_once $this->wp_tests_dir . '/includes/functions.php';


### PR DESCRIPTION
Doing this to prevent the following PHP notice that was happening when running unit tests:

Notice: Constant WC_USE_TRANSACTIONS already defined in wp-content/plugins/woocommerce/tests/bootstrap.php on line 67

After removing this constant, I confirmed that this change didn't break any tests.

Fixes #65 
