### PR TITLE
Configure Travis to run PHPCS checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: php
+
+php:
+  - 7.2
+
+script:
+  - bash tests/bin/travis-setup.sh
+  - bash tests/bin/phpcs.sh
+
+# Specifies that Travis should create builds for master and release branches and also tags.
+branches:
+  only:
+    - master
+    - /^\d+\.\d+(\.\d+)?(-\S*)?$/
+    - /^release\//

--- a/tests/bin/phpcs.sh
+++ b/tests/bin/phpcs.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+CHANGED_FILES=`git diff --name-only --diff-filter=ACMR $TRAVIS_COMMIT_RANGE | grep \\\\.php | awk '{print}' ORS=' '`
+
+if [ "$CHANGED_FILES" != "" ]; then
+	echo "Running Code Sniffer."
+	./vendor/bin/phpcs --ignore=$IGNORE --encoding=utf-8 -n -p $CHANGED_FILES
+fi

--- a/tests/bin/travis-setup.sh
+++ b/tests/bin/travis-setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Remove Xdebug from PHP runtime for all PHP version except 7.1 to speed up builds.
+# We need Xdebug enabled in the PHP 7.1 build job as it is used to generate code coverage.
+phpenv config-rm xdebug.ini
+
+composer install


### PR DESCRIPTION
To test that Travis is calling PHPCS properly, I added a second commit with a coding standard violation to this PR, waited for the Travis build to fail and then removed the commit.

Next, we need to configure it to run PHPUnit tests as well.