### PR TITLE
Fixed backwards compatibility for download data 

### DIFF
--- a/includes/class-wc-product-tables-backwards-compatibility.php
+++ b/includes/class-wc-product-tables-backwards-compatibility.php
@@ -624,7 +624,7 @@ class WC_Product_Tables_Backwards_Compatibility {
 		$query_results = wp_cache_get( 'woocommerce_product_backwards_compatibility_downloadable_files_' . $args['product_id'], 'product' );
 
 		if ( empty( $query_results ) ) {
-			$query_results = $wpdb->get_results( $wpdb->prepare( "SELECT `download_id`, `name`, `file` from {$wpdb->prefix}wc_product_downloads WHERE `product_id` = %d ORDER by priority ASC", $args['product_id'] ) );
+			$query_results = $wpdb->get_results( $wpdb->prepare( "SELECT `download_id`, `name`, `file` from {$wpdb->prefix}wc_product_downloads WHERE `product_id` = %d ORDER by `priority` ASC", $args['product_id'] ) );
 
 			wp_cache_set( 'woocommerce_product_backwards_compatibility_downloadable_files_' . $args['product_id'], $query_results, 'product' );
 		}

--- a/includes/class-wc-product-tables-backwards-compatibility.php
+++ b/includes/class-wc-product-tables-backwards-compatibility.php
@@ -624,7 +624,7 @@ class WC_Product_Tables_Backwards_Compatibility {
 		$query_results = wp_cache_get( 'woocommerce_product_backwards_compatibility_downloadable_files_' . $args['product_id'], 'product' );
 
 		if ( empty( $query_results ) ) {
-			$query_results = $wpdb->get_results( $wpdb->prepare( "SELECT `download_id`, `name`, `file` from {$wpdb->prefix}wc_product_downloads WHERE `product_id` = %d", $args['product_id'] ) );
+			$query_results = $wpdb->get_results( $wpdb->prepare( "SELECT `download_id`, `name`, `file` from {$wpdb->prefix}wc_product_downloads WHERE `product_id` = %d ORDER by priority ASC", $args['product_id'] ) );
 
 			wp_cache_set( 'woocommerce_product_backwards_compatibility_downloadable_files_' . $args['product_id'], $query_results, 'product' );
 		}

--- a/includes/class-wc-product-tables-backwards-compatibility.php
+++ b/includes/class-wc-product-tables-backwards-compatibility.php
@@ -593,7 +593,7 @@ class WC_Product_Tables_Backwards_Compatibility {
 		); // WPCS: db call ok, cache ok.
 
 		if ( $result ) {
-			wp_cache_delete( 'woocommerce_product_' . $args['product_id'], 'product' );
+			wp_cache_delete( 'woocommerce_product_downloads_' . $args['product_id'], 'product' );
 		}
 
 		return $result;
@@ -720,7 +720,7 @@ class WC_Product_Tables_Backwards_Compatibility {
 		}
 
 		wp_cache_delete( 'woocommerce_product_backwards_compatibility_downloadable_files_' . $args['product_id'], 'product' );
-		wp_cache_delete( 'woocommerce_product_' . $args['product_id'], 'product' );
+		wp_cache_delete( 'woocommerce_product_downloads_' . $args['product_id'], 'product' );
 
 		return true;
 	}

--- a/includes/class-wc-product-tables-backwards-compatibility.php
+++ b/includes/class-wc-product-tables-backwards-compatibility.php
@@ -581,7 +581,7 @@ class WC_Product_Tables_Backwards_Compatibility {
 
 		$format = $args['format'] ? array( $args['format'] ) : null;
 
-		return (bool) $wpdb->update(
+		$result = (bool) $wpdb->update(
 			$wpdb->prefix . 'wc_product_downloads',
 			array(
 				$args['column'] => $args['value'],
@@ -591,6 +591,12 @@ class WC_Product_Tables_Backwards_Compatibility {
 			),
 			$format
 		); // WPCS: db call ok, cache ok.
+
+		if ( $result ) {
+			wp_cache_delete( 'woocommerce_product_' . $args['product_id'], 'product' );
+		}
+
+		return $result;
 	}
 
 	/**
@@ -625,15 +631,15 @@ class WC_Product_Tables_Backwards_Compatibility {
 
 		$mapped_results = array();
 		foreach ( $query_results as $result ) {
-			$mapped_results[ $result['download_id'] ] = array(
-				'id'            => $result['download_id'],
-				'name'          => $result['name'],
-				'file'          => $result['file'],
+			$mapped_results[ $result->download_id ] = array(
+				'id'            => $result->download_id,
+				'name'          => $result->name,
+				'file'          => $result->file,
 				'previous_hash' => '',
 			);
 		}
 
-		return $mapped_results;
+		return array( array( $mapped_results ) );
 	}
 
 	/**
@@ -663,10 +669,10 @@ class WC_Product_Tables_Backwards_Compatibility {
 		$new_values = $args['value'];
 		$new_ids    = array_keys( $new_values );
 
-		$existing_file_data        = $wpdb->get_results( $wpdb->prepare( "SELECT `download_id`, `limit`, `expires` FROM {$wpdb->prefix}wc_product_downloads WHERE `product_id` = %d ORDER BY `priority` ASC", $args['product_id'] ) );  // WPCS: db call ok, cache ok.
+		$existing_file_data        = $wpdb->get_results( $wpdb->prepare( "SELECT `download_id`, `limit`, `expires` FROM {$wpdb->prefix}wc_product_downloads WHERE `product_id` = %d ORDER BY `priority` ASC", $args['product_id'] ) ); // WPCS: db call ok, cache ok.
 		$existing_file_data_by_key = array();
 		foreach ( $existing_file_data as $data ) {
-			$existing_file_data_by_key[ $data['download_id'] ] = $data;
+			$existing_file_data_by_key[ $data->download_id ] = $data;
 		}
 		$old_ids = wp_list_pluck( $existing_file_data, 'download_id' );
 		$missing = array_diff( $old_ids, $new_ids );
@@ -691,7 +697,7 @@ class WC_Product_Tables_Backwards_Compatibility {
 				'download_id' => $id,
 				'product_id'  => $args['product_id'],
 				'name'        => isset( $download_info['name'] ) ? $download_info['name'] : '',
-				'url'         => isset( $download_info['file'] ) ? $download_info['file'] : '',
+				'file'        => isset( $download_info['file'] ) ? $download_info['file'] : '',
 				'limit'       => isset( $existing_file_data_by_key[ $id ] ) ? $existing_file_data_by_key[ $id ]['limit'] : null,
 				'expires'     => isset( $existing_file_data_by_key[ $id ] ) ? $existing_file_data_by_key[ $id ]['expires'] : null,
 				'priority'    => $priority,
@@ -710,7 +716,7 @@ class WC_Product_Tables_Backwards_Compatibility {
 				)
 			); // WPCS: db call ok, cache ok.
 
-			++$priority;
+			$priority++;
 		}
 
 		wp_cache_delete( 'woocommerce_product_backwards_compatibility_downloadable_files_' . $args['product_id'], 'product' );
@@ -1571,10 +1577,6 @@ class WC_Product_Tables_Backwards_Compatibility {
 					),
 				),
 			),
-
-			/**
-			 * In downloads table. @todo Products and data stores are not handling this correctly. Was previously meta.
-			 */
 			'_download_limit'        => array(
 				'get'    => array(
 					'function' => array( $this, 'get_from_downloads_table' ),

--- a/tests/unit-tests/class-wc-tests-backwards-compatibility.php
+++ b/tests/unit-tests/class-wc-tests-backwards-compatibility.php
@@ -901,21 +901,41 @@ class WC_Tests_Backwards_Compatibility extends WC_Unit_Test_Case {
 		$this->assertEquals( 'Test download 4', $results[1]['name'] );
 		$this->assertEquals( 'https://woocommerce.com/4', $results[1]['file'] );
 
-		// // Download expiry is soft deprecated now and should return -1.
-		// $_product = wc_get_product( $product->get_id() );
-		// $this->assertEquals( -1, $_product->get_downloadable_files() );
+		$_product = wc_get_product( $product->get_id() );
+		$results  = array_values( $_product->get_downloads() );
+		$this->assertEquals( 'Test download 3', $results[0]['name'] );
+		$this->assertEquals( 'https://woocommerce.com/3', $results[0]['file'] );
+		$this->assertEquals( 'Test download 4', $results[1]['name'] );
+		$this->assertEquals( 'https://woocommerce.com/4', $results[1]['file'] );
 
-		// delete_post_meta( $product->get_id(), '_downloadable_files' );
-		// $this->assertEquals( -1, get_post_meta( $product->get_id(), '_downloadable_files', true ) );
+		delete_post_meta( $product->get_id(), '_downloadable_files' );
+		$this->assertEquals( array(), get_post_meta( $product->get_id(), '_downloadable_files', true ) );
 
-		// // Download expiry is soft deprecated now and should return -1.
-		// $_product = wc_get_product( $product->get_id() );
-		// $this->assertEquals( -1, $_product->get_downloadable_files() );
+		$_product = wc_get_product( $product->get_id() );
+		$this->assertEquals( array(), $_product->get_downloads() );
 
-		// add_post_meta( $product->get_id(), '_downloadable_files', 3 );
+		add_post_meta( $product->get_id(), '_downloadable_files', array(
+			array(
+				'name'   => 'Test download 3',
+				'file'   => 'https://woocommerce.com/3',
+				'limit'  => '',
+				'expiry' => '',
+			),
+			array(
+				'name'   => 'Test download 4',
+				'file'   => 'https://woocommerce.com/4',
+				'limit'  => '',
+				'expiry' => '',
+			),
+		) );
 
-		// $this->assertEquals( array(), $this->get_from_meta_table( $product->get_id(), '_downloadable_files' ) );
-		// $this->assertEquals( 3, get_post_meta( $product->get_id(), '_downloadable_files', true ) );
+		$this->assertEquals( array(), $this->get_from_meta_table( $product->get_id(), '_downloadable_files' ) );
+
+		$results = array_values( get_post_meta( $product->get_id(), '_downloadable_files', true ) );
+		$this->assertEquals( 'Test download 3', $results[0]['name'] );
+		$this->assertEquals( 'https://woocommerce.com/3', $results[0]['file'] );
+		$this->assertEquals( 'Test download 4', $results[1]['name'] );
+		$this->assertEquals( 'https://woocommerce.com/4', $results[1]['file'] );
 	}
 
 	/**

--- a/tests/unit-tests/class-wc-tests-backwards-compatibility.php
+++ b/tests/unit-tests/class-wc-tests-backwards-compatibility.php
@@ -765,17 +765,14 @@ class WC_Tests_Backwards_Compatibility extends WC_Unit_Test_Case {
 	 *
 	 * @since 1.0.0
 	 */
-
-	/*
-	@todo Need to figure out how we're handling backwards compatibility for these since products have multiple download limits and expiries now.
 	public function test_download_limit_mapping() {
 		$product = new WC_Product_Simple();
 		$product->set_downloadable( true );
 		$product->set_downloads( array(
 			array(
-				'name' => 'Test download',
-				'file' => 'https://woocommerce.com',
-				'limit' => 5,
+				'name'   => 'Test download',
+				'file'   => 'https://woocommerce.com',
+				'limit'  => 5,
 				'expiry' => '',
 			),
 		) );
@@ -789,9 +786,16 @@ class WC_Tests_Backwards_Compatibility extends WC_Unit_Test_Case {
 		$this->assertEquals( array(), $this->get_from_meta_table( $product->get_id(), '_download_limit' ) );
 		$this->assertEquals( 10, get_post_meta( $product->get_id(), '_download_limit', true ) );
 
-		// @todo Instantiate a product object and check it got updated should pass.
+		// Download limit is soft deprecated now and should return -1.
+		$_product = wc_get_product( $product->get_id() );
+		$this->assertEquals( -1, $_product->get_download_limit() );
+
 		delete_post_meta( $product->get_id(), '_download_limit' );
 		$this->assertEquals( -1, get_post_meta( $product->get_id(), '_download_limit', true ) );
+
+		// Download limit is soft deprecated now and should return -1.
+		$_product = wc_get_product( $product->get_id() );
+		$this->assertEquals( -1, $_product->get_download_limit() );
 
 		add_post_meta( $product->get_id(), '_download_limit', 3 );
 
@@ -799,14 +803,120 @@ class WC_Tests_Backwards_Compatibility extends WC_Unit_Test_Case {
 		$this->assertEquals( 3, get_post_meta( $product->get_id(), '_download_limit', true ) );
 	}
 
-	public function test_download_expiry() {
+	/**
+	 * Test the download expiry metadata mapping.
+	 *
+	 * @since 1.0.0
+	 */
+	public function test_download_expiry_mapping() {
+		$product = new WC_Product_Simple();
+		$product->set_downloadable( true );
+		$product->set_downloads( array(
+			array(
+				'name'   => 'Test download',
+				'file'   => 'https://woocommerce.com',
+				'limit'  => '',
+				'expiry' => 120,
+			),
+		) );
+		$product->save();
 
+		$this->assertEquals( array(), $this->get_from_meta_table( $product->get_id(), '_download_expiry' ) );
+		$this->assertEquals( 120, get_post_meta( $product->get_id(), '_download_expiry', true ) );
+
+		update_post_meta( $product->get_id(), '_download_expiry', 10 );
+
+		$this->assertEquals( array(), $this->get_from_meta_table( $product->get_id(), '_download_expiry' ) );
+		$this->assertEquals( 10, get_post_meta( $product->get_id(), '_download_expiry', true ) );
+
+		// Download expiry is soft deprecated now and should return -1.
+		$_product = wc_get_product( $product->get_id() );
+		$this->assertEquals( -1, $_product->get_download_expiry() );
+
+		delete_post_meta( $product->get_id(), '_download_expiry' );
+		$this->assertEquals( -1, get_post_meta( $product->get_id(), '_download_expiry', true ) );
+
+		// Download expiry is soft deprecated now and should return -1.
+		$_product = wc_get_product( $product->get_id() );
+		$this->assertEquals( -1, $_product->get_download_expiry() );
+
+		add_post_meta( $product->get_id(), '_download_expiry', 3 );
+
+		$this->assertEquals( array(), $this->get_from_meta_table( $product->get_id(), '_download_expiry' ) );
+		$this->assertEquals( 3, get_post_meta( $product->get_id(), '_download_expiry', true ) );
 	}
 
+	/**
+	 * Test downloads files metadata mapping.
+	 *
+	 * @since 1.0.0
+	 */
 	public function test_downloadable_files_mapping() {
+		$product = new WC_Product_Simple();
+		$product->set_downloadable( true );
+		$product->set_downloads( array(
+			array(
+				'name'   => 'Test download',
+				'file'   => 'https://woocommerce.com',
+				'limit'  => '',
+				'expiry' => '',
+			),
+			array(
+				'name'   => 'Test download 2',
+				'file'   => 'https://woocommerce.com/2',
+				'limit'  => '',
+				'expiry' => '',
+			),
+		) );
+		$product->save();
 
+		$this->assertEquals( array(), $this->get_from_meta_table( $product->get_id(), '_downloadable_files' ) );
+
+		$results = array_values( get_post_meta( $product->get_id(), '_downloadable_files', true ) );
+		$this->assertEquals( 'Test download', $results[0]['name'] );
+		$this->assertEquals( 'https://woocommerce.com', $results[0]['file'] );
+		$this->assertEquals( 'Test download 2', $results[1]['name'] );
+		$this->assertEquals( 'https://woocommerce.com/2', $results[1]['file'] );
+
+		update_post_meta( $product->get_id(), '_downloadable_files', array(
+			array(
+				'name'   => 'Test download 3',
+				'file'   => 'https://woocommerce.com/3',
+				'limit'  => '',
+				'expiry' => '',
+			),
+			array(
+				'name'   => 'Test download 4',
+				'file'   => 'https://woocommerce.com/4',
+				'limit'  => '',
+				'expiry' => '',
+			),
+		) );
+
+		$this->assertEquals( array(), $this->get_from_meta_table( $product->get_id(), '_downloadable_files' ) );
+
+		$results = array_values( get_post_meta( $product->get_id(), '_downloadable_files', true ) );
+		$this->assertEquals( 'Test download 3', $results[0]['name'] );
+		$this->assertEquals( 'https://woocommerce.com/3', $results[0]['file'] );
+		$this->assertEquals( 'Test download 4', $results[1]['name'] );
+		$this->assertEquals( 'https://woocommerce.com/4', $results[1]['file'] );
+
+		// // Download expiry is soft deprecated now and should return -1.
+		// $_product = wc_get_product( $product->get_id() );
+		// $this->assertEquals( -1, $_product->get_downloadable_files() );
+
+		// delete_post_meta( $product->get_id(), '_downloadable_files' );
+		// $this->assertEquals( -1, get_post_meta( $product->get_id(), '_downloadable_files', true ) );
+
+		// // Download expiry is soft deprecated now and should return -1.
+		// $_product = wc_get_product( $product->get_id() );
+		// $this->assertEquals( -1, $_product->get_downloadable_files() );
+
+		// add_post_meta( $product->get_id(), '_downloadable_files', 3 );
+
+		// $this->assertEquals( array(), $this->get_from_meta_table( $product->get_id(), '_downloadable_files' ) );
+		// $this->assertEquals( 3, get_post_meta( $product->get_id(), '_downloadable_files', true ) );
 	}
-	*/
 
 	/**
 	 * Test the variation description metadata mapping.


### PR DESCRIPTION
This fixes backwards compatibility methods to handle downloadable data, this includes deprecating `get_download_limit()` and `get_download_expiry()` to always return `-1`.