### PR TITLE
Improvements to WC_Product_Variable_Data_Store_Custom_Table::sync_managed_variation_stock_status()

### DIFF
--- a/includes/data-stores/class-wc-product-variable-data-store-custom-table.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-custom-table.php
@@ -467,7 +467,7 @@ class WC_Product_Variable_Data_Store_Custom_Table extends WC_Product_Data_Store_
 			$children = $product->get_children();
 
 			if ( ! empty( $children ) ) {
-				$wpdb->query(
+				$changed = $wpdb->query(
 					$wpdb->prepare(
 						"UPDATE {$wpdb->prefix}wc_products
 						SET stock_status = %s
@@ -476,9 +476,11 @@ class WC_Product_Variable_Data_Store_Custom_Table extends WC_Product_Data_Store_
 					)
 				);
 
-				$children = $this->read_children( $product, true );
-				$product->set_children( $children['all'] );
-				$product->set_visible_children( $children['visible'] );
+				if ( $changed ) {
+					$children = $this->read_children( $product, true );
+					$product->set_children( $children['all'] );
+					$product->set_visible_children( $children['visible'] );
+				}
 			}
 		}
 	}

--- a/includes/data-stores/class-wc-product-variable-data-store-custom-table.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-custom-table.php
@@ -465,17 +465,21 @@ class WC_Product_Variable_Data_Store_Custom_Table extends WC_Product_Data_Store_
 		if ( $product->get_manage_stock() ) {
 			$status   = $product->get_stock_status();
 			$children = $product->get_children();
-			$wpdb->query(
-				$wpdb->prepare(
-					"UPDATE {$wpdb->prefix}wc_products
-					SET stock_status = %s
-					WHERE product_id IN (" . implode( ',', array_map( 'absint', $children ) ) . ')', // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared,
-					$status
-				)
-			);
-			$children = $this->read_children( $product, true );
-			$product->set_children( $children['all'] );
-			$product->set_visible_children( $children['visible'] );
+
+			if ( ! empty( $children ) ) {
+				$wpdb->query(
+					$wpdb->prepare(
+						"UPDATE {$wpdb->prefix}wc_products
+						SET stock_status = %s
+						WHERE product_id IN (" . implode( ',', array_map( 'absint', $children ) ) . ')', // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared,
+						$status
+					)
+				);
+
+				$children = $this->read_children( $product, true );
+				$product->set_children( $children['all'] );
+				$product->set_visible_children( $children['visible'] );
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR makes two improvements to the method WC_Product_Variable_Data_Store_Custom_Table::sync_managed_variation_stock_status():

- It fixes a MySQL error when running the method for a variable product with no variations by adding a check to see if the variable product has any children before running the query to update them. This error was happening when running the PHPUnit test WC_Tests_Product_Variable::test_variable_product_auto_stock_status(). Commit 3c58da0
- It adds a check to only update product variable children data if their stock status changed following the same pattern used by the WC core method with the same name. Commit 
b212ae6 