### PR TITLE
Clear backwards compatibility cache when clearing product data store caches

### DIFF
--- a/includes/class-wc-product-tables-backwards-compatibility.php
+++ b/includes/class-wc-product-tables-backwards-compatibility.php
@@ -164,15 +164,19 @@ class WC_Product_Tables_Backwards_Compatibility {
 			return array();
 		}
 
-		$data = wp_cache_get( 'woocommerce_product_backwards_compatibility_' . $args['column'] . '_' . $args['product_id'], 'product' );
+		$data = wp_cache_get( 'woocommerce_product_backwards_compatibility_' . $args['product_id'], 'product' );
 
-		if ( empty( $data ) ) {
-			$data = $wpdb->get_col( $wpdb->prepare( 'SELECT `' . esc_sql( $args['column'] ) . "` from {$wpdb->prefix}wc_products WHERE product_id = %d", $args['product_id'] ) ); // WPCS: db call ok.
-
-			wp_cache_set( 'woocommerce_product_backwards_compatibility_' . $args['column'] . '_' . $args['product_id'], $data, 'product' );
+		if ( false === $data ) {
+			$data = array();
 		}
 
-		return $data;
+		if ( empty( $data[ $args['column'] ] ) ) {
+			$data[ $args['column'] ] = $wpdb->get_col( $wpdb->prepare( 'SELECT `' . esc_sql( $args['column'] ) . "` from {$wpdb->prefix}wc_products WHERE product_id = %d", $args['product_id'] ) ); // WPCS: db call ok.
+
+			wp_cache_set( 'woocommerce_product_backwards_compatibility_' . $args['product_id'], $data, 'product' );
+		}
+
+		return $data[ $args['column'] ];
 	}
 
 	/**
@@ -238,7 +242,7 @@ class WC_Product_Tables_Backwards_Compatibility {
 		}
 
 		if ( $update_success ) {
-			wp_cache_delete( 'woocommerce_product_backwards_compatibility_' . $args['column'] . '_' . $args['product_id'], 'product' );
+			wp_cache_delete( 'woocommerce_product_backwards_compatibility_' . $args['product_id'], 'product' );
 			wp_cache_delete( 'woocommerce_product_' . $args['product_id'], 'product' );
 		}
 

--- a/includes/data-stores/class-wc-product-data-store-custom-table.php
+++ b/includes/data-stores/class-wc-product-data-store-custom-table.php
@@ -598,6 +598,7 @@ class WC_Product_Data_Store_Custom_Table extends WC_Data_Store_WP implements WC_
 		wp_cache_delete( 'woocommerce_product_' . $product->get_id(), 'product' );
 		wp_cache_delete( 'woocommerce_product_relationships_' . $product->get_id(), 'product' );
 		wp_cache_delete( 'woocommerce_product_downloads_' . $product->get_id(), 'product' );
+		wp_cache_delete( 'woocommerce_product_backwards_compatibility_' . $product->get_id(), 'product' );
 		wc_delete_product_transients( $product->get_id() );
 	}
 


### PR DESCRIPTION
This commit adds code to clean the backwards compatibility cache created for each product on WC_Product_Tables_Backwards_Compatibility::get_from_product_table() whenever a product is changed and WC_Product_Data_Store_Custom_Table::clear_caches() is called. To be able to do this it was necessary to change the way the backwards compatibility class caches information. Instead of creating a cache entry for each product property, now the class will create a cache entry for each product. So now all product properties are now stored in the same cache entry.

This change fixes two failing tests. Fixes #75 

cc @claudiulodro 