### PR TITLE
Implement missing method WC_Product_Variable_Data_Store_Custom_Table::child_has_stock_status()

### DIFF
--- a/includes/data-stores/class-wc-product-variation-data-store-custom-table.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-custom-table.php
@@ -655,4 +655,14 @@ class WC_Product_Variation_Data_Store_Custom_Table extends WC_Product_Data_Store
 			}
 		}
 	}
+
+	/**
+	 * Clear product variations specific caches and calls parent::clear_caches() to clear the remaining product caches.
+	 *
+	 * @param WC_Product $product The product object.
+	 */
+	protected function clear_caches( &$product ) {
+		wp_cache_delete( 'woocommerce_product_children_stock_status_' . $product->get_parent_id(), 'product' );
+		parent::clear_caches( $product );
+	}
 }


### PR DESCRIPTION
This commit implements the missing method WC_Product_Variable_Data_Store_Custom_Table::child_has_stock_status() to make syncing variable product stock status work properly when children are out of stock or on backorder. Before this change, syncing was working only when children are in stock.

Fix #82