### PR TITLE
Include custom product tables tests in the phpunit.xml file

### DIFF
--- a/includes/class-wc-product-tables-backwards-compatibility.php
+++ b/includes/class-wc-product-tables-backwards-compatibility.php
@@ -33,7 +33,7 @@ class WC_Product_Tables_Backwards_Compatibility {
 	 */
 	public function get_metadata_from_tables( $result, $post_id, $meta_key, $single ) {
 		$mapping = $this->get_mapping();
-		if ( ( defined( 'WC_PRODUCT_TABLES_MIGRATING' ) && WC_PRODUCT_TABLES_MIGRATING ) || ! isset( $mapping[ $meta_key ] ) ) {
+		if ( WC_Product_Tables_Migrate_Data::$migrating || ! isset( $mapping[ $meta_key ] ) ) {
 			return $result;
 		}
 
@@ -66,7 +66,7 @@ class WC_Product_Tables_Backwards_Compatibility {
 	 */
 	public function add_metadata_to_tables( $result, $post_id, $meta_key, $meta_value, $unique ) {
 		$mapping = $this->get_mapping();
-		if ( ( defined( 'WC_PRODUCT_TABLES_MIGRATING' ) && WC_PRODUCT_TABLES_MIGRATING ) || ! isset( $mapping[ $meta_key ] ) ) {
+		if ( WC_Product_Tables_Migrate_Data::$migrating || ! isset( $mapping[ $meta_key ] ) ) {
 			return $result;
 		}
 
@@ -97,7 +97,7 @@ class WC_Product_Tables_Backwards_Compatibility {
 	 */
 	public function update_metadata_in_tables( $result, $post_id, $meta_key, $meta_value, $prev_value ) {
 		$mapping = $this->get_mapping();
-		if ( ( defined( 'WC_PRODUCT_TABLES_MIGRATING' ) && WC_PRODUCT_TABLES_MIGRATING ) || ! isset( $mapping[ $meta_key ] ) ) {
+		if ( WC_Product_Tables_Migrate_Data::$migrating || ! isset( $mapping[ $meta_key ] ) ) {
 			return $result;
 		}
 
@@ -122,7 +122,7 @@ class WC_Product_Tables_Backwards_Compatibility {
 	 */
 	public function delete_metadata_from_tables( $result, $post_id, $meta_key, $prev_value, $delete_all ) {
 		$mapping = $this->get_mapping();
-		if ( ( defined( 'WC_PRODUCT_TABLES_MIGRATING' ) && WC_PRODUCT_TABLES_MIGRATING ) || ! isset( $mapping[ $meta_key ] ) ) {
+		if ( WC_Product_Tables_Migrate_Data::$migrating || ! isset( $mapping[ $meta_key ] ) ) {
 			return $result;
 		}
 

--- a/includes/class-wc-product-tables-migrate-data.php
+++ b/includes/class-wc-product-tables-migrate-data.php
@@ -57,6 +57,13 @@ class WC_Product_Tables_Migrate_Data {
 	);
 
 	/**
+	 * Whether or not the migration is currently running.
+	 *
+	 * @var bool
+	 */
+	public static $migrating = false;
+
+	/**
 	 * Main function that runs the whole migration.
 	 *
 	 * @param bool $clean_old_data Whether to clean old data or keep it. Old data is kept by default.
@@ -64,7 +71,7 @@ class WC_Product_Tables_Migrate_Data {
 	public static function migrate( $clean_old_data = false ) {
 		global $wpdb;
 
-		define( 'WC_PRODUCT_TABLES_MIGRATING', true );
+		self::$migrating = true;
 
 		$products = self::get_products();
 
@@ -144,6 +151,8 @@ class WC_Product_Tables_Migrate_Data {
 				self::clean_old_data( $product->ID );
 			}
 		}
+
+		self::$migrating = false;
 	}
 
 	/**

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -10,7 +10,10 @@
 	syntaxCheck="true"
 	>
 	<testsuites>
-		<testsuite name="WooCommerce Test Suite">
+		<testsuite name="WooCommerce Product Custom Tables Suite">
+			<directory suffix=".php">tests/unit-tests</directory>
+		</testsuite>
+		<testsuite name="WooCommerce Core Test Suite">
 			<directory suffix=".php">./../woocommerce/tests/unit-tests</directory>
 		</testsuite>
 	</testsuites>


### PR DESCRIPTION
This PR updates the phpunit.xml file to include custom product tables own tests in the list of tests to run. Before, PHPUnit was configured to run only WC core tests.

To avoid conflicts between the two different tests suites, it was necessary to change the way WC_Product_Tables_Migrate_Data defines if the data migration is currently running or not. The original method used a constant which couldn't be changed after the migration was over.