### PR TITLE
Downloads changes

### DIFF
--- a/includes/class-wc-product-tables-backwards-compatibility.php
+++ b/includes/class-wc-product-tables-backwards-compatibility.php
@@ -586,7 +586,7 @@ class WC_Product_Tables_Backwards_Compatibility {
 		$new_values = $args['value'];
 		$new_ids    = array_keys( $new_values );
 
-		$existing_file_data        = $wpdb->get_results( $wpdb->prepare( "SELECT `download_id`, `limit`, `expires` FROM {$wpdb->prefix}wc_product_downloads WHERE `product_id` = %d ORDER BY `priority` ASC", $args['product_id'] ) ); // WPCS: db call ok, cache ok.
+		$existing_file_data        = $wpdb->get_results( $wpdb->prepare( "SELECT `download_id` FROM {$wpdb->prefix}wc_product_downloads WHERE `product_id` = %d ORDER BY `priority` ASC", $args['product_id'] ) ); // WPCS: db call ok, cache ok.
 		$existing_file_data_by_key = array();
 		foreach ( $existing_file_data as $data ) {
 			$existing_file_data_by_key[ $data->download_id ] = $data;
@@ -615,8 +615,6 @@ class WC_Product_Tables_Backwards_Compatibility {
 				'product_id'  => $args['product_id'],
 				'name'        => isset( $download_info['name'] ) ? $download_info['name'] : '',
 				'file'        => isset( $download_info['file'] ) ? $download_info['file'] : '',
-				'limit'       => isset( $existing_file_data_by_key[ $id ] ) ? $existing_file_data_by_key[ $id ]['limit'] : null,
-				'expires'     => isset( $existing_file_data_by_key[ $id ] ) ? $existing_file_data_by_key[ $id ]['expires'] : null,
 				'priority'    => $priority,
 			);
 

--- a/tests/unit-tests/class-wc-tests-backwards-compatibility.php
+++ b/tests/unit-tests/class-wc-tests-backwards-compatibility.php
@@ -761,49 +761,6 @@ class WC_Tests_Backwards_Compatibility extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test the download limit metadata mapping.
-	 *
-	 * @since 1.0.0
-	 */
-	public function test_download_limit_mapping() {
-		$product = new WC_Product_Simple();
-		$product->set_downloadable( true );
-		$product->set_downloads( array(
-			array(
-				'name'   => 'Test download',
-				'file'   => 'https://woocommerce.com',
-				'limit'  => 5,
-				'expiry' => '',
-			),
-		) );
-		$product->save();
-
-		$this->assertEquals( array(), $this->get_from_meta_table( $product->get_id(), '_download_limit' ) );
-		$this->assertEquals( 5, get_post_meta( $product->get_id(), '_download_limit', true ) );
-
-		update_post_meta( $product->get_id(), '_download_limit', 10 );
-
-		$this->assertEquals( array(), $this->get_from_meta_table( $product->get_id(), '_download_limit' ) );
-		$this->assertEquals( 10, get_post_meta( $product->get_id(), '_download_limit', true ) );
-
-		// Download limit is soft deprecated now and should return -1.
-		$_product = wc_get_product( $product->get_id() );
-		$this->assertEquals( -1, $_product->get_download_limit() );
-
-		delete_post_meta( $product->get_id(), '_download_limit' );
-		$this->assertEquals( -1, get_post_meta( $product->get_id(), '_download_limit', true ) );
-
-		// Download limit is soft deprecated now and should return -1.
-		$_product = wc_get_product( $product->get_id() );
-		$this->assertEquals( -1, $_product->get_download_limit() );
-
-		add_post_meta( $product->get_id(), '_download_limit', 3 );
-
-		$this->assertEquals( array(), $this->get_from_meta_table( $product->get_id(), '_download_limit' ) );
-		$this->assertEquals( 3, get_post_meta( $product->get_id(), '_download_limit', true ) );
-	}
-
-	/**
 	 * Test the download expiry metadata mapping.
 	 *
 	 * @since 1.0.0

--- a/tests/unit-tests/class-wc-tests-backwards-compatibility.php
+++ b/tests/unit-tests/class-wc-tests-backwards-compatibility.php
@@ -761,49 +761,6 @@ class WC_Tests_Backwards_Compatibility extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test the download expiry metadata mapping.
-	 *
-	 * @since 1.0.0
-	 */
-	public function test_download_expiry_mapping() {
-		$product = new WC_Product_Simple();
-		$product->set_downloadable( true );
-		$product->set_downloads( array(
-			array(
-				'name'   => 'Test download',
-				'file'   => 'https://woocommerce.com',
-				'limit'  => '',
-				'expiry' => 120,
-			),
-		) );
-		$product->save();
-
-		$this->assertEquals( array(), $this->get_from_meta_table( $product->get_id(), '_download_expiry' ) );
-		$this->assertEquals( 120, get_post_meta( $product->get_id(), '_download_expiry', true ) );
-
-		update_post_meta( $product->get_id(), '_download_expiry', 10 );
-
-		$this->assertEquals( array(), $this->get_from_meta_table( $product->get_id(), '_download_expiry' ) );
-		$this->assertEquals( 10, get_post_meta( $product->get_id(), '_download_expiry', true ) );
-
-		// Download expiry is soft deprecated now and should return -1.
-		$_product = wc_get_product( $product->get_id() );
-		$this->assertEquals( -1, $_product->get_download_expiry() );
-
-		delete_post_meta( $product->get_id(), '_download_expiry' );
-		$this->assertEquals( -1, get_post_meta( $product->get_id(), '_download_expiry', true ) );
-
-		// Download expiry is soft deprecated now and should return -1.
-		$_product = wc_get_product( $product->get_id() );
-		$this->assertEquals( -1, $_product->get_download_expiry() );
-
-		add_post_meta( $product->get_id(), '_download_expiry', 3 );
-
-		$this->assertEquals( array(), $this->get_from_meta_table( $product->get_id(), '_download_expiry' ) );
-		$this->assertEquals( 3, get_post_meta( $product->get_id(), '_download_expiry', true ) );
-	}
-
-	/**
 	 * Test downloads files metadata mapping.
 	 *
 	 * @since 1.0.0


### PR DESCRIPTION
Update backward compatibility functionality for product downloads to be compatible with the newer version of the table.

No more limit and expires fields per file, but only as a whole.