### PR TITLE
Use WC_Admin_Notices::add_custom_notice instead of add_notice

### DIFF
--- a/woocommerce-product-tables-feature-plugin.php
+++ b/woocommerce-product-tables-feature-plugin.php
@@ -43,7 +43,8 @@ function wc_custom_product_tables_bootstrap() {
 	}
 
 	if ( version_compare( WC_VERSION, '3.5.dev', '<' ) ) {
-		WC_Admin_Notices::add_notice( __( 'You need WooCommerce 3.5 development version or higher to run the Custom Product Tables plugin.', 'woocommerce' ) );
+		WC_Admin_Notices::add_custom_notice( 'wc_custom_product_tables_need_wc', __( 'You need WooCommerce 3.5 development version or higher to run the Custom Product Tables plugin.', 'woocommerce' ) );
+
 		return;
 	}
 


### PR DESCRIPTION
Fixes #115

WC_Admin_Notices::add_notice is to be used for core WC notices.

WC_Admin_Notices::add_custom_notice is for custom notices. Which this is it.

To test:

* check out master
* have WooCommerce 3.4.4
* activate feature plugin
* see that there is no notice
* have Query Monitor plugin, see that it's trying to query for a `woocommerce_admin_notice_You need WooCommerce 3.5 development version or higher to run the Custom Product Tables plugin.` option
* check out this branch
* reload page
* see that the notice shows up on the admin screen as expected