### PR TITLE
Drop tables only if they exist

### DIFF
--- a/includes/class-wc-product-tables-cli.php
+++ b/includes/class-wc-product-tables-cli.php
@@ -44,7 +44,7 @@ class WC_Product_Tables_Cli {
 	 */
 	public function recreate_tables() {
 		global $wpdb;
-		$wpdb->query( "DROP TABLE {$wpdb->prefix}wc_products, {$wpdb->prefix}wc_product_downloads, {$wpdb->prefix}wc_product_attributes, {$wpdb->prefix}wc_product_relationships, {$wpdb->prefix}wc_product_attribute_values, {$wpdb->prefix}wc_product_variation_attribute_values" );
+		$wpdb->query( "DROP TABLE IF EXISTS {$wpdb->prefix}wc_products, {$wpdb->prefix}wc_product_downloads, {$wpdb->prefix}wc_product_attributes, {$wpdb->prefix}wc_product_relationships, {$wpdb->prefix}wc_product_attribute_values, {$wpdb->prefix}wc_product_variation_attribute_values" );
 		WC_Product_Tables_Install::activate();
 	}
 }


### PR DESCRIPTION
This commit adds an `IF EXISTS` check to the MySQL query that is executed to drop all the tables installed by this plugin when WC_Product_Tables_Cli::recreate_tables() is called. Doing this to prevent an unknown table MySQL error in case one of the tables don't exist.

Refs #125 