### PR TITLE
Implement `get_query_for_stock` from WC core

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-custom-table.php
+++ b/includes/data-stores/class-wc-product-data-store-custom-table.php
@@ -2273,4 +2273,23 @@ class WC_Product_Data_Store_Custom_Table extends WC_Data_Store_WP implements WC_
 
 		return $products;
 	}
+
+	/**
+	 * Returns query statement for getting current `stock_quantity` of a product.
+	 *
+	 * @internal MAX function below is used to make sure result is a scalar.
+	 * @param int $product_id Product ID.
+	 * @return string|void Query statement.
+	 */
+	public function get_query_for_stock( $product_id ) { 
+		global $wpdb;
+		return $wpdb->prepare(
+			"
+			SELECT COALESCE ( MAX( stock_quantity ), 0 ) FROM {$wpdb->prefix}wc_products
+			
+			WHERE product_id = %d
+			",
+			$product_id
+		);
+	}
 }

--- a/includes/data-stores/class-wc-product-data-store-custom-table.php
+++ b/includes/data-stores/class-wc-product-data-store-custom-table.php
@@ -2286,7 +2286,6 @@ class WC_Product_Data_Store_Custom_Table extends WC_Data_Store_WP implements WC_
 		return $wpdb->prepare(
 			"
 			SELECT COALESCE ( MAX( stock_quantity ), 0 ) FROM {$wpdb->prefix}wc_products
-			
 			WHERE product_id = %d
 			",
 			$product_id


### PR DESCRIPTION
WooCommerce Core implemented a method to get the current stock quantity for a product. This patch brings that functionality into the feature plugin as well.

Without this patch, customers are unable to checkout with any product that is managing inventory levels.

See core method https://github.com/woocommerce/woocommerce/blob/09d98a6fe059c4a0c5e88a549213a08b56314e85/includes/data-stores/class-wc-product-data-store-cpt.php#L2112

**Testing:**
*Before applying this patch*
- Create a product that has an inventory stock level
- Add items to the cart
- Proceed through checkout
- Verify checkout fails with a not enough stock notice

*After applying this patch*
- Add the product with an inventory stock level to cart
- Proceed through checkout
- Verify checkout is successful
- Verify stock count was decremented appropriately